### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Available fields you can insert into the output is:
 - `column`: Column number of the error.
 - `path`: Path to the module with the error.
 - `msg`: The actual error message.
-- `C`: (captial C) The first letter of the message category.
+- `C`: (capital C) The first letter of the message category.
 - `category`: The category of the message, either Info, Refactor, Convention, Warning, Error or Fatal.
 - `symbol`: The symbolic name of the message, like `unused-variable` for `W0612`.
 


### PR DESCRIPTION
@thusoy, I've corrected a typographical error in the documentation of the [grunt-pylint](https://github.com/thusoy/grunt-pylint) project. Specifically, I've changed captial to capital. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.