### PR TITLE
Unable to install on Mac due to already-installed modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "devsetup": "cd tasks/lib && pip install pylint==1.5.4 astroid==1.4.4 colorama==0.3.6 six==1.10.0 lazy-object-proxy==1.2.1 wrapt==1.10.6 --download . --no-use-wheel",
     "prepublish": "grunt clean",
-    "postinstall": "cd tasks/lib && pip install --no-index --no-deps ./pylint-1.5.4.tar.gz ./astroid-1.4.4.tar.gz ./colorama-0.3.6.tar.gz ./six-1.10.0.tar.gz ./lazy-object-proxy-1.2.1.tar.gz ./wrapt-1.10.6.tar.gz --target ."
+    "postinstall": "cd tasks/lib && pip install --no-index --no-deps --ignore-installed ./pylint-1.5.4.tar.gz ./astroid-1.4.4.tar.gz ./colorama-0.3.6.tar.gz ./six-1.10.0.tar.gz ./lazy-object-proxy-1.2.1.tar.gz ./wrapt-1.10.6.tar.gz --target ."
   },
   "devDependencies": {
     "grunt": ">=0.4.0",


### PR DESCRIPTION
I was not able to install this module with npm on Mac because pip was attempting to uninstall the system version of six. This module is installed in the system's Python framework and cannot be uninstalled even with `sudo`. I added the `--ignore-installed` flag to avoid attempting to uninstall existing versions of these modules.

After making this change, I had errors due to missing .tar.gz files since the `devsetup` script was not running. The README indicates that the script can be run with `npm`, but in my case there was no way to install the module since the `postinstall` script failed due to the tarballs not downloading. I changed the `devsetup` task to `preinstall`, but after reading the README it seems that this entire download and installation process was intended to be optional. Is it appropriate to instead use a single `devsetup` script that installs the dependencies rather than bothering with the tarballs?