### PR TITLE
Update pylint

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,8 +6,17 @@ node_modules
 npm-debug.log
 reports
 tasks/lib/astroid
+tasks/lib/backports
 tasks/lib/colorama
+tasks/lib/concurrent
+tasks/lib/configparser.py
+tasks/lib/enum
+tasks/lib/isort
+tasks/lib/lazy_object_proxy
 tasks/lib/logilab
+tasks/lib/mccabe.py
 tasks/lib/pylint
+tasks/lib/singledispatch.py
 tasks/lib/six.py
+tasks/lib/wrapt
 grunt-pylint*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -12,9 +12,7 @@ reports
 tasks/lib/astroid
 tasks/lib/backports
 tasks/lib/colorama
-tasks/lib/concurrent
 tasks/lib/configparser.py
-tasks/lib/enum
 tasks/lib/isort
 tasks/lib/lazy_object_proxy
 tasks/lib/logilab

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,11 @@
-*.pyc
 *.dist-info
 *.pth
+*.pyc
 *venv
+.editorconfig
+.jshintrc
+.travis.yml
+grunt-pylint*.tgz
 node_modules
 npm-debug.log
 reports
@@ -19,4 +23,4 @@ tasks/lib/pylint
 tasks/lib/singledispatch.py
 tasks/lib/six.py
 tasks/lib/wrapt
-grunt-pylint*.tgz
+test/

--- a/.npmignore
+++ b/.npmignore
@@ -10,15 +10,11 @@ node_modules
 npm-debug.log
 reports
 tasks/lib/astroid
-tasks/lib/backports
-tasks/lib/colorama
-tasks/lib/configparser.py
 tasks/lib/isort
 tasks/lib/lazy_object_proxy
-tasks/lib/logilab
 tasks/lib/mccabe.py
 tasks/lib/pylint
-tasks/lib/singledispatch.py
 tasks/lib/six.py
+tasks/lib/typed_ast
 tasks/lib/wrapt
 test/

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 *.dist-info
 *.pth
 *.pyc
+__pycache__
 *venv
 .editorconfig
 .jshintrc

--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ node_modules
 npm-debug.log
 reports
 tasks/lib/astroid
+tasks/lib/bin
 tasks/lib/isort
 tasks/lib/lazy_object_proxy
 tasks/lib/mccabe.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - 2.7
   - 3.4
   - 3.5
   - 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 
 python:
   - 2.7
-  - 3.3
   - 3.4
+  - 3.5
+  - 3.6
 
 install:
   - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,9 +104,9 @@ module.exports = function (grunt) {
         },
         src: 'test/fixtures/test_package',
       },
-      HTMLOutput: {
+      JsonOutput: {
         options: {
-          outputFormat: 'html',
+          outputFormat: 'json',
         },
         src: 'test/fixtures/test_package',
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,6 +128,12 @@ module.exports = function (grunt) {
         },
         src: 'test/fixtures/test_package',
       },
+      score: {
+        options: {
+          score: true,
+        },
+        src: 'test/fixtures/test_package',
+      }
     },
 
     nodeunit: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,8 @@ module.exports = function (grunt) {
       ],
       testResults: [
         'reports',
+      ],
+      testHookOutput: [
         'inithooktest',
       ],
       compiledStuff: [
@@ -146,5 +148,5 @@ module.exports = function (grunt) {
   grunt.loadTasks('tasks');
 
   grunt.registerTask('default', ['jshint', 'test']);
-  grunt.registerTask('test', ['clean', 'pylint', 'nodeunit']);
+  grunt.registerTask('test', ['clean', 'pylint', 'nodeunit', 'clean:testHookOutput']);
 };

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 ### Unreleased
 You can now set `GRUNT_PYLINT_SKIP_POSTINSTALL=y` to work around installation issues.
 Enable setting `score` to show a code quality score.
-Remove support for python 3.3.
+Remove support for python2.7 and python 3.
 
 ### v1.3.1 (2016-03-10)
 Add compatibility with pip < 1.5

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Default: `false`
 
 Whether to include a full report or just the messages.
 
+#### score
+Type: 'Boolean'
+Default: `false`
+
+Whether to print a score summary.
+
 #### virtualenv
 Type: `String`  
 
@@ -188,6 +194,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 ## Changelog
 
 ### Unreleased
+Enable setting `score` to show a code quality score.
 Remove support for python 3.3.
 
 ### v1.3.1 (2016-03-10)

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ A file to save the output to.
 
 #### outputFormat
 Type: `String`  
-Alternatives: `text|colorized`
+Alternatives: `text|colorized|json`
 Default: `"colorized"`
 
-What format the output will be in.
+What format the output will be in. If set to `json` the `messageTemplate` will be ignored.
 
 #### rcfile
 Type: `String`  

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ A file to save the output to.
 
 #### outputFormat
 Type: `String`  
-Alternatives: `text|colorized|html`
+Alternatives: `text|colorized`
 Default: `"colorized"`
 
-What format the output will be in. Specifying `options.outputFormat = "html"` will ignore anything set by `options.messageFormat`.
+What format the output will be in.
 
 #### rcfile
 Type: `String`  

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 You can now set `GRUNT_PYLINT_SKIP_POSTINSTALL=y` to work around installation issues.
 Enable setting `score` to show a code quality score.
 Remove support for python2.7 and python 3.
+Update bundled pylint to 2.3.1.
 
 ### v1.3.1 (2016-03-10)
 Add compatibility with pip < 1.5

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Changelog
 
+### Unreleased
+Remove support for python 3.3.
+
 ### v1.3.1 (2016-03-10)
 Add compatibility with pip < 1.5
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out th
 npm install grunt-pylint --save-dev
 ```
 
-**Note**: Installation requires the python package manager `pip` to be in your `$PATH` ([installation instructions](https://pip.pypa.io/en/stable/installing/)) (it does not however, require networking -- all dependencies are bundled with the source)
+**Note**: Installation requires the python package manager `pip` (and `python` itself) to be in your `$PATH` ([installation instructions](https://pip.pypa.io/en/stable/installing/)) (it does not however, require networking -- all dependencies are bundled with the source)
 
 Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
 
 ```js
 grunt.loadNpmTasks('grunt-pylint');
 ```
+
+If you're having issues with installing the package due to the postinstall step, you can use your own version of pylint. Set the environment variable `GRUNT_PYLINT_SKIP_POSTINSTALL=yes` before installation, install `pylint` in your environment, and set `externalPylint: true` in the task.
 
 ## The "pylint" task
 
@@ -194,6 +196,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 ## Changelog
 
 ### Unreleased
+You can now set `GRUNT_PYLINT_SKIP_POSTINSTALL=y` to work around installation issues.
 Enable setting `score` to show a code quality score.
 Remove support for python 3.3.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "devsetup": "cd tasks/lib && pip install -U setuptools && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
+    "devsetup": "cd tasks/lib && pip install setuptools>=40.7 && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
     "postinstall": "python postinstall.py"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "devsetup": "cd tasks/lib && pip install setuptools>=40.7 && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
+    "devsetup": "cd tasks/lib && pip install setuptools>=40.7 && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.1.1 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
     "postinstall": "python postinstall.py"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "devsetup": "cd tasks/lib && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
+    "devsetup": "cd tasks/lib && pip install setuptools>=24.2.0 && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
     "postinstall": "cd tasks/lib && pip install --no-index --no-deps --ignore-installed ./pylint-1.5.4.tar.gz ./astroid-1.4.4.tar.gz ./colorama-0.3.6.tar.gz ./six-1.10.0.tar.gz ./lazy-object-proxy-1.2.1.tar.gz ./wrapt-1.10.6.tar.gz --target ."
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "devsetup": "cd tasks/lib && pip install -U setuptools && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
-    "postinstall": "cd tasks/lib && pip install --no-index --no-deps --ignore-installed ./astroid-1.6.6.tar.gz ./backports.functools_lru_cache-1.5.tar.gz ./configparser-3.7.4.tar.gz ./enum34-1.1.6.tar.gz ./futures-3.2.0.tar.gz ./isort-4.3.17.tar.gz ./lazy-object-proxy-1.3.1.tar.gz ./mccabe-0.6.1.tar.gz ./pylint-1.9.4.tar.gz ./singledispatch-3.4.0.3.tar.gz ./six-1.12.0.tar.gz ./wrapt-1.11.1.tar.gz --target ."
+    "postinstall": "python postinstall.py"
   },
   "devDependencies": {
     "grunt": ">=0.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "devsetup": "cd tasks/lib && pip install setuptools>=24.2.0 && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
+    "devsetup": "cd tasks/lib && pip install setuptools>=36.2.0 && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
     "postinstall": "cd tasks/lib && pip install --no-index --no-deps --ignore-installed ./pylint-1.5.4.tar.gz ./astroid-1.4.4.tar.gz ./colorama-0.3.6.tar.gz ./six-1.10.0.tar.gz ./lazy-object-proxy-1.2.1.tar.gz ./wrapt-1.10.6.tar.gz --target ."
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "devsetup": "cd tasks/lib && pip install \"setuptools>=40.7\" && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
+    "devsetup": "cd tasks/lib && pip install \"setuptools>=40.7\" && pip download astroid==2.2.5 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==2.3.1 six==1.12.0 typed-ast==1.3.1 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
     "postinstall": "python postinstall.py"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "devsetup": "cd tasks/lib && pip install setuptools>=36.2.0 && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
+    "devsetup": "cd tasks/lib && pip install -U setuptools && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
     "postinstall": "cd tasks/lib && pip install --no-index --no-deps --ignore-installed ./pylint-1.5.4.tar.gz ./astroid-1.4.4.tar.gz ./colorama-0.3.6.tar.gz ./six-1.10.0.tar.gz ./lazy-object-proxy-1.2.1.tar.gz ./wrapt-1.10.6.tar.gz --target ."
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "devsetup": "cd tasks/lib && pip install setuptools>=40.7 && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
+    "devsetup": "cd tasks/lib && pip install \"setuptools>=40.7\" && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
     "postinstall": "python postinstall.py"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "devsetup": "cd tasks/lib && pip download pylint==1.5.4 astroid==1.4.4 colorama==0.3.6 six==1.10.0 lazy-object-proxy==1.2.1 wrapt==1.10.6 --no-binary :all:",
+    "devsetup": "cd tasks/lib && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
     "postinstall": "cd tasks/lib && pip install --no-index --no-deps --ignore-installed ./pylint-1.5.4.tar.gz ./astroid-1.4.4.tar.gz ./colorama-0.3.6.tar.gz ./six-1.10.0.tar.gz ./lazy-object-proxy-1.2.1.tar.gz ./wrapt-1.10.6.tar.gz --target ."
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "devsetup": "cd tasks/lib && pip install \"setuptools>=40.7\" && pip download astroid==2.2.5 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==2.3.1 six==1.12.0 typed-ast==1.3.1 wrapt==1.11.1 --no-binary :all:",
+    "devsetup": "cd tasks/lib && pip install \"setuptools>=40.7\" && pip download astroid==2.2.5 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==2.3.1 six==1.12.0 typed-ast==1.3.1 typing==3.6.6 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
     "postinstall": "python postinstall.py"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "devsetup": "cd tasks/lib && pip install -U setuptools && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.2.0 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
-    "postinstall": "cd tasks/lib && pip install --no-index --no-deps --ignore-installed ./pylint-1.5.4.tar.gz ./astroid-1.4.4.tar.gz ./colorama-0.3.6.tar.gz ./six-1.10.0.tar.gz ./lazy-object-proxy-1.2.1.tar.gz ./wrapt-1.10.6.tar.gz --target ."
+    "postinstall": "cd tasks/lib && pip install --no-index --no-deps --ignore-installed ./astroid-1.6.6.tar.gz ./backports.functools_lru_cache-1.5.tar.gz ./configparser-3.7.4.tar.gz ./enum34-1.1.6.tar.gz ./futures-3.2.0.tar.gz ./isort-4.3.17.tar.gz ./lazy-object-proxy-1.3.1.tar.gz ./mccabe-0.6.1.tar.gz ./pylint-1.9.4.tar.gz ./singledispatch-3.4.0.3.tar.gz ./six-1.12.0.tar.gz ./wrapt-1.11.1.tar.gz --target ."
   },
   "devDependencies": {
     "grunt": ">=0.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
-    "devsetup": "cd tasks/lib && pip install setuptools>=40.7 && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 enum34==1.1.6 futures==3.1.1 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
+    "devsetup": "cd tasks/lib && pip install setuptools>=40.7 && pip download astroid==1.6.6 backports.functools-lru-cache==1.5 configparser==3.7.4 isort==4.3.17 lazy-object-proxy==1.3.1 mccabe==0.6.1 pylint==1.9.4 singledispatch==3.4.0.3 six==1.12.0 wrapt==1.11.1 --no-binary :all:",
     "prepublish": "grunt clean",
     "postinstall": "python postinstall.py"
   },

--- a/postinstall.py
+++ b/postinstall.py
@@ -18,18 +18,10 @@ packages = [
     'wrapt-1.11.1.tar.gz',
 ]
 
-py3_packages = [
-    'enum34-1.1.6.tar.gz',
-    'futures-3.1.1.tar.gz',
-]
-
 
 def main():
     if os.environ.get('GRUNT_PYLINT_SKIP_POSTINSTALL', 'no').lower().startswith('y'):
         return
-
-    if sys.version_info < (3, 0, 0):
-        packages.extend(py3_packages)
 
     install_cmd = [
         'pip',

--- a/postinstall.py
+++ b/postinstall.py
@@ -16,10 +16,17 @@ packages = [
     'wrapt-1.11.1.tar.gz',
 ]
 
+py34_packages = [
+    'typing-3.6.6.tar.gz',
+]
+
 
 def main():
     if os.environ.get('GRUNT_PYLINT_SKIP_POSTINSTALL', 'no').lower().startswith('y'):
         return
+
+    if sys.version_info < (3, 5, 0):
+        packages.extend(py34_packages)
 
     install_cmd = [
         'pip',

--- a/postinstall.py
+++ b/postinstall.py
@@ -23,7 +23,10 @@ def main():
     if os.environ.get('GRUNT_PYLINT_SKIP_POSTINSTALL', 'no').lower().startswith('y'):
         return
 
-    # Ensure configparser installs correctly with pip>=18
+    # With pip >= 18 and setuptools < 40.7, configparser will use the PEP 518
+    # build system and try to install a newer setuptools, which will fail due to
+    # the --no-index flag we pass to prevent network access. Thus disable the
+    # PEP 518 build system to ensure we stay offline.
     os.environ['PIP_NO_BUILD_ISOLATION'] = 'n'
 
     install_cmd = [

--- a/postinstall.py
+++ b/postinstall.py
@@ -23,6 +23,9 @@ def main():
     if os.environ.get('GRUNT_PYLINT_SKIP_POSTINSTALL', 'no').lower().startswith('y'):
         return
 
+    # Ensure configparser installs correctly with pip>=18
+    os.environ['PIP_NO_BUILD_ISOLATION'] = 'n'
+
     install_cmd = [
         'pip',
         'install',

--- a/postinstall.py
+++ b/postinstall.py
@@ -6,15 +6,13 @@ import sys
 
 # Versions here must match what is bundled with the package (see package.json)
 packages = [
-    'astroid-1.6.6.tar.gz',
-    'backports.functools_lru_cache-1.5.tar.gz',
-    'configparser-3.7.4.tar.gz',
+    'astroid-2.2.5.tar.gz',
     'isort-4.3.17.tar.gz',
     'lazy-object-proxy-1.3.1.tar.gz',
     'mccabe-0.6.1.tar.gz',
-    'pylint-1.9.4.tar.gz',
-    'singledispatch-3.4.0.3.tar.gz',
+    'pylint-2.3.1.tar.gz',
     'six-1.12.0.tar.gz',
+    'typed-ast-1.3.1.tar.gz',
     'wrapt-1.11.1.tar.gz',
 ]
 
@@ -22,12 +20,6 @@ packages = [
 def main():
     if os.environ.get('GRUNT_PYLINT_SKIP_POSTINSTALL', 'no').lower().startswith('y'):
         return
-
-    # With pip >= 18 and setuptools < 40.7, configparser will use the PEP 518
-    # build system and try to install a newer setuptools, which will fail due to
-    # the --no-index flag we pass to prevent network access. Thus disable the
-    # PEP 518 build system to ensure we stay offline.
-    os.environ['PIP_NO_BUILD_ISOLATION'] = 'n'
 
     install_cmd = [
         'pip',

--- a/postinstall.py
+++ b/postinstall.py
@@ -39,7 +39,17 @@ def main():
     for package in packages:
         install_cmd.append('./' + package)
 
-    subprocess.check_call(install_cmd, cwd='tasks/lib')
+    try:
+        subprocess.check_call(install_cmd, cwd='tasks/lib')
+    except subprocess.CalledProcessError as e:
+        if e.returncode != 2:
+            raise e
+
+        # Try to work around a faulty patch applied by debian to pip
+        # https://github.com/pypa/pip/issues/3826
+        sys.stderr.write('Installing pylint dependencies failed, retrying with --system\n')
+        install_cmd.append('--system')
+        subprocess.check_call(install_cmd, cwd='tasks/lib')
 
 
 if __name__ == '__main__':

--- a/postinstall.py
+++ b/postinstall.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import subprocess
 import sys
 
@@ -24,6 +25,9 @@ py3_packages = [
 
 
 def main():
+    if os.environ.get('GRUNT_PYLINT_SKIP_POSTINSTALL', 'no').lower().startswith('y'):
+        return
+
     if sys.version_info < (3, 0, 0):
         packages.extend(py3_packages)
 

--- a/postinstall.py
+++ b/postinstall.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import subprocess
+import sys
+
+# Versions here must match what is bundled with the package (see package.json)
+packages = [
+    'astroid-1.6.6.tar.gz',
+    'backports.functools_lru_cache-1.5.tar.gz',
+    'configparser-3.7.4.tar.gz',
+    'isort-4.3.17.tar.gz',
+    'lazy-object-proxy-1.3.1.tar.gz',
+    'mccabe-0.6.1.tar.gz',
+    'pylint-1.9.4.tar.gz',
+    'singledispatch-3.4.0.3.tar.gz',
+    'six-1.12.0.tar.gz',
+    'wrapt-1.11.1.tar.gz',
+]
+
+py3_packages = [
+    'enum34-1.1.6.tar.gz',
+    'futures-3.2.0.tar.gz',
+]
+
+
+def main():
+    if sys.version_info < (3, 0, 0):
+        packages.extend(py3_packages)
+
+    install_cmd = [
+        'pip',
+        'install',
+        '--no-index',
+        '--no-deps',
+        '--ignore-installed',
+        '--target', '.',
+    ]
+
+    for package in packages:
+        install_cmd.append('./' + package)
+
+    subprocess.check_call(install_cmd, cwd='tasks/lib')
+
+
+if __name__ == '__main__':
+    main()
+

--- a/postinstall.py
+++ b/postinstall.py
@@ -20,7 +20,7 @@ packages = [
 
 py3_packages = [
     'enum34-1.1.6.tar.gz',
-    'futures-3.2.0.tar.gz',
+    'futures-3.1.1.tar.gz',
 ]
 
 

--- a/tasks/pylint.js
+++ b/tasks/pylint.js
@@ -119,6 +119,15 @@ module.exports = function (grunt) {
       pylintArgs.push('--rcfile=' + rcfile);
     }
 
+    var score = options.score;
+    delete options.score;
+
+    if (score) {
+      pylintArgs.push('--score=y');
+    } else {
+      pylintArgs.push('--score=n');
+    }
+
     var errorsOnly = options.errorsOnly;
     delete options.errorsOnly;
 
@@ -160,6 +169,7 @@ module.exports = function (grunt) {
       outputFormat: 'colorized',
       messageTemplate: 'short',
       report: false,
+      score: false,
       externalPylint: false,
     });
 

--- a/test/fixtures/test_package/camelcasefunc.py
+++ b/test/fixtures/test_package/camelcasefunc.py
@@ -2,4 +2,3 @@
 
 def camelCaseFunc():
     """ This function has a bad name. """
-    pass

--- a/test/fixtures/test_package/unusedvariable.py
+++ b/test/fixtures/test_package/unusedvariable.py
@@ -1,5 +1,5 @@
 """ This file should trigger linting error for unused variable. """
 
 def unused_variable_func():
-    """ Note the camelcase name and unused variable. Bad bad bad."""
+    """ Note the unused variable. Bad bad bad."""
     unused = 1

--- a/test/test_reports.js
+++ b/test/test_reports.js
@@ -7,7 +7,8 @@ exports.testMsgTemplate = function (test) {
   test.expect(2);
   testutils.readReport('messageTemplate', function (lines) {
     test.equal(lines.length, 4);
-    test.ok(lines.indexOf('3: Invalid function name "camelCaseFunc"') > 0);
+    test.ok(lines.indexOf('3: Function name "camelCaseFunc" doesn\'t conform to ' +
+      'snake_case naming style') > 0);
     test.done();
   });
 };
@@ -25,7 +26,8 @@ exports.testDisable = function (test) {
   test.expect(2);
   testutils.readReport('disable', function (lines) {
     test.equal(lines.length, 2);
-    test.equal(lines[1], 'line 3: Invalid function name "camelCaseFunc" (invalid-name)');
+    test.equal(lines[1], 'line 3: Function name "camelCaseFunc" doesn\'t conform to ' +
+      'snake_case naming style (invalid-name)');
     test.done();
   });
 };
@@ -53,7 +55,8 @@ exports.testIgnore = function (test) {
   test.expect(2);
   testutils.readReport('ignore', function (lines) {
     test.equal(lines.length, 2);
-    test.equal(lines[1], 'line 3: Invalid function name "camelCaseFunc" (invalid-name)');
+    test.equal(lines[1], 'line 3: Function name "camelCaseFunc" doesn\'t conform to ' +
+      'snake_case naming style (invalid-name)');
     test.done();
   });
 };
@@ -91,7 +94,8 @@ exports.testTaskConfigOverridesRcfile = function (test) {
   test.expect(2);
   testutils.readReport('taskOverridesRc', function (lines) {
     test.equal(lines.length, 2);
-    test.equal(lines[1], 'line 3: Invalid function name "camelCaseFunc" (invalid-name)');
+    test.equal(lines[1], 'line 3: Function name "camelCaseFunc" doesn\'t conform to ' +
+      'snake_case naming style (invalid-name)');
     test.done();
   });
 };
@@ -99,15 +103,16 @@ exports.testTaskConfigOverridesRcfile = function (test) {
 exports.testTemplateAliases = function (test) {
   test.expect(2);
   testutils.readReport('templateAliases', function (lines) {
+    test.equal(lines.length, 4);
     // if on windows, make sure to use unix style slashes for the test
     for (var i = 0; i < 4; i++) {
       while (lines[i].indexOf('\\') > 0) {
         lines[i] = lines[i].replace('\\', '/');
       }
     }
-    test.equal(lines.length, 4);
     test.ok(lines.indexOf('test/fixtures/test_package/camelcasefunc.py:3: ' +
-      '[C0103(invalid-name), camelCaseFunc] Invalid function name "camelCaseFunc"') > 0);
+      '[C0103(invalid-name), camelCaseFunc] Function name "camelCaseFunc" doesn\'t conform to ' +
+      'snake_case naming style') > 0);
     test.done();
   });
 };
@@ -116,7 +121,8 @@ exports.testReport = function (test) {
   test.expect(3);
   testutils.readReport('report', function (lines) {
     test.ok(lines.length > 10);
-    test.ok(lines.indexOf('line 3: Invalid function name "camelCaseFunc" (invalid-name)') > 0);
+    test.ok(lines.indexOf('line 3: Function name "camelCaseFunc" doesn\'t conform to snake_case ' +
+      'naming style (invalid-name)') > 0);
     test.equal(lines[6], 'Report');
     test.done();
   });

--- a/test/test_reports.js
+++ b/test/test_reports.js
@@ -120,3 +120,12 @@ exports.testReport = function (test) {
     test.done();
   });
 };
+
+exports.testScore = function (test) {
+  test.expect(2);
+  testutils.readReport('score', function (lines) {
+    test.equal(lines.length, 7);
+    test.ok(lines[6].startsWith('Your code has been rated at 5.00/10'));
+    test.done();
+  });
+};

--- a/test/test_reports.js
+++ b/test/test_reports.js
@@ -72,11 +72,10 @@ exports.testMultipleSrcFiles = function (test) {
 };
 
 exports.testJsonOutput = function (test) {
-  test.expect(2);
+  test.expect(1);
   testutils.readReport('JsonOutput', function (lines) {
     var obj = JSON.parse(lines.join(''));
     test.equal(obj.length, 2);
-    test.equal(obj[0].symbol, 'unused-variable');
     test.done();
   });
 };

--- a/test/test_reports.js
+++ b/test/test_reports.js
@@ -68,10 +68,12 @@ exports.testMultipleSrcFiles = function (test) {
   });
 };
 
-exports.testHTMLOutput = function (test) {
-  test.expect(1);
-  testutils.readReport('HTMLOutput', function (lines) {
-    test.equal(lines[0], '<html>');
+exports.testJsonOutput = function (test) {
+  test.expect(2);
+  testutils.readReport('JsonOutput', function (lines) {
+    var obj = JSON.parse(lines.join(''));
+    test.equal(obj.length, 2);
+    test.equal(obj[0].symbol, 'unused-variable');
     test.done();
   });
 };

--- a/test/test_reports.js
+++ b/test/test_reports.js
@@ -131,7 +131,7 @@ exports.testScore = function (test) {
   test.expect(2);
   testutils.readReport('score', function (lines) {
     test.equal(lines.length, 7);
-    test.ok(lines[6].startsWith('Your code has been rated at 5.00/10'));
+    test.ok(lines[6].startsWith('Your code has been rated at 3.33/10'));
     test.done();
   });
 };

--- a/test/test_reports.js
+++ b/test/test_reports.js
@@ -81,7 +81,6 @@ exports.testInitHook = function (test) {
   // Should have created this file
   fs.readFile('inithooktest', function (path, data) {
     test.equal(data, 'testdata');
-    fs.unlink('inithooktest');
     test.done();
   });
 };


### PR DESCRIPTION
Also drops support for python2 and python3.3 since it's too much work to maintain a dual-version setup, and python2 is EOL soon anyway.

Closes #20.